### PR TITLE
Added option to use url Params to switch server & arena

### DIFF
--- a/Game.Engine/wwwroot/js/connection.ts
+++ b/Game.Engine/wwwroot/js/connection.ts
@@ -58,6 +58,7 @@ export class Connection {
         if (this.socket) this.socket.close();
     }
     connect(world?) {
+
         let url;
         if (window.location.protocol === "https:") {
             url = "wss:";
@@ -83,7 +84,7 @@ export class Connection {
         url += "/api/v1/connect?";
 
         if (world) url += `world=${encodeURIComponent(world)}&`;
-
+        
         if (this.socket) {
             this.socket.onclose = () => {};
             this.socket.close();

--- a/Game.Engine/wwwroot/js/lobby.ts
+++ b/Game.Engine/wwwroot/js/lobby.ts
@@ -69,6 +69,23 @@ const controls = document.querySelector(".controls");
 const social = document.querySelector(".social");
 let showing = false;
 let firstLoad = true;
+var hostName = window.location.hash;
+var worldConnect = "default";
+
+if (firstLoad) {      
+    var url = new URL(window.location.href);
+    var hostParam = url.searchParams.get('host');
+
+    if (hostParam != null) {
+        hostName = hostParam;
+    }  else {
+        hostName = url.host;
+    }
+    
+    var worldParam = url.searchParams.get('world');
+
+    if (worldParam != null) { worldConnect = worldParam; }
+}
 
 export const LobbyCallbacks = {
     onLobbyClose: null,
@@ -84,6 +101,7 @@ function refreshList(autoJoinWorld) {
     if (!showing && !firstLoad && !autoJoinWorld) return;
 
     const autoJoin = firstLoad || autoJoinWorld;
+
     firstLoad = false;
 
     fetch("/api/v1/world/all", {
@@ -94,15 +112,17 @@ function refreshList(autoJoinWorld) {
     })
         .then(r => r.json())
         .then(({ success, response }) => {
+            var world = worldConnect;
             if (success) {
                 if (window.location.hash) {
                     const selected = window.location.hash.substring(1);
                     window.Game.primaryConnection.connect(selected);
                 }
 
+                var JoinServer = hostName + "/" + worldConnect;
                 buildList(response);
-
-                if (autoJoin) joinWorld(autoJoinWorld || "us.daud.io/default");
+                
+                if (autoJoin) joinWorld(autoJoinWorld || JoinServer);
             }
         });
 }


### PR DESCRIPTION
Added 2 new url parameter options (to make it quiker to jump to a specific server/ arena):
- 'host' : to provide daud server
- 'world' : to provide daud arena

Ways to use this params inclue:

`daud.io/?host=eu.daud.io` : This will redirect user to the EU default (FFA) arena on load.

`daud.io/?world=duel` : This will redirect user to the US duel arena upon load.

`daud.io?/host=eu.daud.io&world=duel` : This will redirect user to the EU duel room on load.

**Known Issue:** Changing the url params once loaded redirects back to old url. Current work around for this is to either use the arena switcher button from spawn screen or to open the changed url on a different tab.