### PR TITLE
Player size based bot respawn delay

### DIFF
--- a/Game.API.Common/Models/Hook.cs
+++ b/Game.API.Common/Models/Hook.cs
@@ -64,6 +64,7 @@
                     BotPerXPoints = 500,
                     BotBase = 1,
                     BotRespawnDelay = 10000,
+                    BotMaxRespawnDelay = 60000,
 
                     StepTime = 40,
                     Wormholes = 0,
@@ -284,6 +285,7 @@
         public float OutOfBoundsBorder { get; set; } = 0;
         public float OutOfBoundsDecayDistance { get; set; } = 4000;
         public int BotRespawnDelay { get; set; }
+        public int BotMaxRespawnDelay { get; set; }
         public int PickupShields { get; set; }
         public int ShieldStrength { get; set; }
 

--- a/Game.Engine/Core/Robot.cs
+++ b/Game.Engine/Core/Robot.cs
@@ -47,10 +47,13 @@
         {
             base.OnDeath(player);
 
-            if (OneLifeOnly)
+            if (OneLifeOnly) { 
                 PendingDestruction = true;
-            else
-                SpawnTimeAfter = World.Time + World.Hook.BotRespawnDelay;
+            } else { 
+                var delay = (World.Hook.BotRespawnDelay * World.AdvertisedPlayerCount) + 1;
+                delay = delay < World.Hook.BotMaxRespawnDelay ? delay : World.Hook.BotMaxRespawnDelay;
+                SpawnTimeAfter = World.Time + delay;
+            }
         }
 
         public override void Think()


### PR DESCRIPTION
- Bot respawn delay is now based on the 'BotRespawnDelay' hook property multiplied by the number of players in the arena.
- Created a new hook property called 'BotMaxRespawnDelay' which is used to define the Maximum delay for a bot (e.g. 60000ms which is 1 minute). If the `BotRespawnDelay * Total Number of Players` exceed this maximum delay value then, the delay will be set to this Maximum delay Value instead.