### PR TITLE
Reset Arena Record Every 24 hours

### DIFF
--- a/Game.Engine/Core/SystemActors/Leaderboard.cs
+++ b/Game.Engine/Core/SystemActors/Leaderboard.cs
@@ -1,6 +1,7 @@
 ﻿namespace Game.Engine.Core.SystemActors
 {
     using Game.API.Common;
+    using System;
     using System.Collections.Generic;
     using System.Linq;
     using System.Numerics;
@@ -47,7 +48,21 @@
 
             var firstPlace = leaderboard.Entries.FirstOrDefault();
             if (World.Leaderboard != null && firstPlace?.Score > World.Leaderboard.ArenaRecord.Score)
+            {
                 leaderboard.ArenaRecord = firstPlace;
+                World.ArenaRecordResetTime = World.Time + 86400000;
+                World.ArenaRecordHasReset = false;
+            }
+
+
+            if (World.Leaderboard != null && !World.ArenaRecordHasReset && World.Time >= World.ArenaRecordResetTime)
+            {
+                Console.WriteLine("Arena Record Score Reseting.");
+                leaderboard.ArenaRecord.Score = 0;
+                leaderboard.ArenaRecord.Name = "";
+                leaderboard.ArenaRecord.FleetID = 0;
+                World.ArenaRecordHasReset = true;
+            }
 
             return leaderboard;
         }
@@ -87,6 +102,7 @@
                 })
                 .ToList());
 
+            
             return new Leaderboard
             {
                 Entries = entries,

--- a/Game.Engine/Core/World.cs
+++ b/Game.Engine/Core/World.cs
@@ -48,6 +48,8 @@
 
         // most recent leaderboard available
         public Leaderboard Leaderboard = null;
+        public bool ArenaRecordHasReset { get; set; } = false;
+        public long ArenaRecordResetTime { get; set; } = 0;
 
         public Func<Fleet, Vector2> FleetSpawnPositionGenerator { get; set; }
         public Func<Leaderboard> LeaderboardGenerator { get; set; }


### PR DESCRIPTION
- Automatically reset the Arena Record score 24 hours (1 day) after it has been achived by a player.  (The 24 hour period will automatically reset once the current arena high score has been beaten).